### PR TITLE
Several functions added for dBZ analysis in EnKF

### DIFF
--- a/src/enkf/enkf.f90
+++ b/src/enkf/enkf.f90
@@ -97,6 +97,8 @@ module enkf
 !                used to be the same) and the "chunks" come from loadbal
 !   2018-05-31:  whitaker:  add modulated ensemble model-space vertical
 !                localization (neigv>0) and denkf option.
+!   2022-04-01:  Yongming Wang and X. Wang: Fix spurious analysis increments when assimilating reflectivity
+!                poc: xuguang.wang@ou.edu
 !
 ! attributes:
 !   language: f95
@@ -182,7 +184,7 @@ real(r_single), allocatable, dimension(:) :: paoverpb_min, paoverpb_min1, paover
 integer(i_kind) ierr
 ! kd-tree search results
 type(kdtree2_result),dimension(:),allocatable :: sresults1,sresults2 
-integer(i_kind) nanal,nn,nnn,nobm,nsame,nn1,nn2,oz_ind,nlev
+integer(i_kind) nanal,nn,nnn,nobm,nsame,nn1,nn2,oz_ind,nlev,dbz_ind
 real(r_single),dimension(nlevs_pres):: taperv
 logical lastiter, kdgrid, kdobs
 
@@ -609,6 +611,7 @@ do niter=1,numiter
           nn2 = ncdim
       end if
       if (nf2 > 0) then
+          dbz_ind = getindex(cvars3d, 'dbz')
 !$omp parallel do schedule(dynamic,1) private(ii,i,nb,obt,nn,nnn,nlev,lnsig,kfgain,ens_tmp,taper1,taper3,taperv)
           do ii=1,nf2 ! loop over nearby horiz grid points
              do nb=1,nbackgrounds ! loop over background time levels
@@ -628,8 +631,13 @@ do niter=1,numiter
                        ! (through hpfhtcon)
                        kfgain=taper1*sum(ens_tmp*anal_obtmp_modens)
                        ! update mean.
-                       ensmean_chunk(i,nn,nb) = ensmean_chunk(i,nn,nb) + &
-                                                kfgain*obinc_tmp
+                       if ( (nn >= (dbz_ind-1)*nlevs+1 .and. nn <= (dbz_ind-1)*nlevs+nlevs) )then
+                          ensmean_chunk(i,nn,nb) = max(ensmean_chunk(i,nn,nb) + &
+                                                        kfgain*obinc_tmp,zero)
+                       else
+                          ensmean_chunk(i,nn,nb) = ensmean_chunk(i,nn,nb) + &
+                                                    kfgain*obinc_tmp
+                       end if
                        ! update perturbations.
                        anal_chunk(:,i,nn,nb) = anal_chunk(:,i,nn,nb) + &
                                                kfgain*obganl(:)
@@ -652,7 +660,11 @@ do niter=1,numiter
                         ! (through hpfhtcon)
                         kfgain=taperv(nnn)*sum(anal_chunk(:,i,nn,nb)*anal_obtmp)
                         ! update mean.
-                        ensmean_chunk(i,nn,nb) = ensmean_chunk(i,nn,nb) + kfgain*obinc_tmp
+                        if ( (nn >= (dbz_ind-1)*nlevs+1 .and. nn <= (dbz_ind-1)*nlevs+nlevs) )then
+                           ensmean_chunk(i,nn,nb) = max(ensmean_chunk(i,nn,nb) + kfgain*obinc_tmp,zero)
+                        else
+                           ensmean_chunk(i,nn,nb) = ensmean_chunk(i,nn,nb) + kfgain*obinc_tmp
+                        end if
                         ! update perturbations.
                         anal_chunk(:,i,nn,nb) = anal_chunk(:,i,nn,nb) + kfgain*obganl(:)
                     end if
@@ -681,7 +693,13 @@ do niter=1,numiter
                           taper(obt*obtimelinv)* &
                           sum(anal_obchunk_modens(:,nob2)*anal_obtmp_modens)*hpfhtcon
                  ! update mean.
-                 ensmean_obchunk(nob2) = ensmean_obchunk(nob2) + kfgain*obinc_tmp
+                 nob3 = indxproc_obs(nproc+1,nob2)
+                 if(trim(obtype(nob3)) == 'dbz' ) then
+                    ensmean_obchunk(nob2) = max((ensmean_obchunk(nob2) + &
+                                            kfgain*obinc_tmp),zero)
+                 else
+                    ensmean_obchunk(nob2) = ensmean_obchunk(nob2) + kfgain*obinc_tmp
+                 end if
                  ! update perturbations.
                  anal_obchunk(:,nob2) = anal_obchunk(:,nob2) + kfgain*obganl
                  anal_obchunk_modens(:,nob2) = anal_obchunk_modens(:,nob2) + kfgain*obganl_modens
@@ -707,7 +725,13 @@ do niter=1,numiter
                            taper(lnsig*lnsiglinv)*taper(obt*obtimelinv)* &
                            sum(anal_obchunk(:,nob2)*anal_obtmp)*hpfhtcon
                   ! update mean.
-                  ensmean_obchunk(nob2) = ensmean_obchunk(nob2) + kfgain*obinc_tmp
+                  nob3 = indxproc_obs(nproc+1,nob2)
+                  if(trim(obtype(nob3)) == 'dbz' ) then
+                     ensmean_obchunk(nob2) = max((ensmean_obchunk(nob2) + &
+                                               kfgain*obinc_tmp),zero)
+                  else
+                     ensmean_obchunk(nob2) = ensmean_obchunk(nob2) + kfgain*obinc_tmp
+                  end if
                   ! update perturbations.
                   anal_obchunk(:,nob2) = anal_obchunk(:,nob2) + kfgain*obganl
                   ! recompute ob space spread ratio  for unassimlated obs
@@ -758,6 +782,7 @@ do niter=1,numiter
   tend = mpi_wtime()
   if (nproc .eq. 0) then
       write(6,8003) niter,'timing on proc',nproc,' = ',tend-tbegin,t2,t3,t4,t5,t6,nrej
+      if(allocated(assimltd_flag))deallocate(assimltd_flag)
       allocate(assimltd_flag(nobstot))
       assimltd_flag = 99999
       if (iassim_order == 2) then

--- a/src/enkf/gridinfo_fv3reg.f90
+++ b/src/enkf/gridinfo_fv3reg.f90
@@ -72,10 +72,10 @@ integer(i_kind),                                  public     :: nlevs_pres
 integer(i_kind),public :: npts
 integer(i_kind),public :: ntrunc
 ! supported variable names in anavinfo
-character(len=max_varname_length),public, dimension(15) :: &
+character(len=max_varname_length),public, dimension(16) :: &
   vars3d_supported = [character(len=max_varname_length) :: &
     'u', 'v', 'w', 't', 'q', 'oz', 'cw', 'tsen', 'prse', &
-    'ql', 'qi', 'qr', 'qs', 'qg', 'qnr']
+    'ql', 'qi', 'qr', 'qs', 'qg', 'qnr','dbz']
 character(len=max_varname_length),public, dimension(3) :: &
   vars2d_supported = [character(len=max_varname_length) :: &
     'ps', 'pst', 'sst']

--- a/src/enkf/gridio_fv3reg.f90
+++ b/src/enkf/gridio_fv3reg.f90
@@ -24,6 +24,8 @@ module gridio
   !                   -- add code to update 'delp' directly 
   !                      from analysis icnrements
   !   2022-06- Ting   --  Implement paranc=.true. for fv3-lam 
+  !   2022-04-01 Yongming Wang and X. Wang:  Add interface for read in dBZ
+  !                poc: xuguang.wang@ou.edu
   ! attributes:
   !   language:  f95
   !
@@ -60,17 +62,19 @@ module gridio
 
   !-------------------------------------------------------------------------
   
-  integer(i_kind) ,parameter:: ndynvarslist=6, ntracerslist=8
+  integer(i_kind) ,parameter:: ndynvarslist=6, ntracerslist=8, nphysicslist=1
   character(len=max_varname_length), parameter, dimension(ndynvarslist) :: &
     vardynvars = [character(len=max_varname_length) :: &
       'u', 'v', 'T', 'W', 'DZ', 'delp']
   character(len=max_varname_length), parameter, dimension(ntracerslist) :: &
     vartracers = [character(len=max_varname_length) :: &
       'sphum','o3mr', 'liq_wat','ice_wat','rainwat','snowwat','graupel','rain_nc']
+  character(len=max_varname_length), parameter, dimension(nphysicslist) :: &
+    varphysics = [character(len=max_varname_length) :: 'ref_f3d']
   type type_fv3lamfile 
        logical l_filecombined
-       character(len=max_varname_length), dimension(2):: fv3lamfilename
-       integer (i_kind), dimension(2):: fv3lam_fileid(2)
+       character(len=max_varname_length), dimension(3):: fv3lamfilename
+       integer (i_kind), dimension(3):: fv3lam_fileid
        contains
          procedure, pass(this) :: setupfile => type_bound_setupfile
          procedure, pass(this):: get_idfn => type_bound_getidfn
@@ -104,9 +108,9 @@ contains
 
     ! Define local variables 
     character(len=500) :: filename
-    character(len=:),allocatable :: fv3filename,fv3filename1
+    character(len=:),allocatable :: fv3filename,fv3filename1,fv3filename2
     character(len=7)   :: charnanal
-    integer(i_kind) file_id,file_id1
+    integer(i_kind) file_id,file_id1,file_id2
     real(r_single), dimension(:,:,:), allocatable ::workvar3d,uworkvar3d,&
                         vworkvar3d,tvworkvar3d,tsenworkvar3d,&
                         workprsi,qworkvar3d
@@ -124,6 +128,7 @@ contains
     integer(i_kind) :: nlevsp1
     integer (i_kind):: i,j, k,nn,ntile,nn_tile0, nb,nanal,ne
     integer(i_kind) :: u_ind, v_ind, tv_ind,tsen_ind, q_ind, oz_ind
+    integer(i_kind) :: dbz_ind
     integer(i_kind) :: w_ind, ql_ind, qi_ind, qr_ind, qs_ind, qg_ind, qnr_ind
     integer (i_kind):: ps_ind, sst_ind
     integer (i_kind):: tmp_ind,ifile
@@ -147,6 +152,7 @@ contains
     qs_ind  = getindex(vars3d, 'qs')   ! Q snow (3D)
     qg_ind  = getindex(vars3d, 'qg')   ! Q graupel (3D)
     qnr_ind  = getindex(vars3d, 'qnr') ! N rain (3D)    
+    dbz_ind  = getindex(vars3d, 'dbz')   ! Reflectivity (3D)
 
     ps_ind  = getindex(vars2d, 'ps')  ! Ps (2D)
     sst_ind = getindex(vars2d, 'sst') ! SST (2D)
@@ -191,9 +197,19 @@ contains
               fv3filename1=trim(adjustl(filename))//"_tracer"
               call nc_check( nf90_open(trim(adjustl(fv3filename1)),nf90_nowrite,file_id1),&
                          myname_,'open: '//trim(adjustl(fv3filename1)) )
-              call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
-                                            fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)) )
-              
+              if(dbz_ind > 0) then
+                 fv3filename2=trim(adjustl(filename))//"_phyvar"
+                 call nc_check(nf90_open(trim(adjustl(fv3filename2)),nf90_nowrite,file_id2),&
+                      myname_,'open: '//trim(adjustl(fv3filename2)) )
+              endif
+              if(dbz_ind > 0) then
+                 call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
+                                         fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)),&
+                                         fileid3=file_id2,fv3fn3=trim(adjustl(fv3filename2)))
+              else
+                 call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
+                                         fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)))
+              endif
            endif 
 
          !----------------------------------------------------------------------
@@ -476,6 +492,27 @@ contains
 
            endif
            
+           if (dbz_ind > 0) then
+               varstrname = 'ref_f3d'
+               call fv3lamfile%get_idfn(varstrname,file_id,fv3filename)
+               call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+               do k=1,nlevs
+                   nn = nn_tile0
+                   do j=1,ny_res
+                     do i=1,nx_res
+                       nn=nn+1
+                       vargrid(nn,levels(dbz_ind-1)+k,nb,ne)=max(workvar3d(i,j,nlevs+1-k),0.0_r_kind)
+                     enddo
+                   enddo
+               enddo
+               do k = levels(dbz_ind-1)+1, levels(dbz_ind)
+                   if (nproc .eq. 0)                                               &
+                      write(6,*) 'READFVregional : qnr ',                           &
+                          & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+               enddo
+
+           endif
+
             ! set SST to zero for now
            if (sst_ind > 0) then
                vargrid(:,levels(n3d)+sst_ind,nb,ne) = zero
@@ -549,7 +586,8 @@ contains
                call nc_check( nf90_close(file_id),&
                  myname_,'close '//trim(filename) )
            else
-              do ifile=1,2
+              do ifile=1,3
+                if(dbz_ind <= 0 .and. ifile == 3) cycle
                 file_id=fv3lamfile%fv3lam_fileid(ifile)
                 filename=fv3lamfile%fv3lamfilename(ifile)
                 call nc_check( nf90_close(file_id),&
@@ -601,15 +639,15 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     !----------------------------------------------------------------------
     ! Define variables computed within subroutine
     character(len=500)  :: filename
-    character(len=:),allocatable :: fv3filename,fv3filename1
+    character(len=:),allocatable :: fv3filename,fv3filename1,fv3filename2
     character(len=7)    :: charnanal
 
     !----------------------------------------------------------------------
-    integer(i_kind) :: u_ind, v_ind, tv_ind, tsen_ind,q_ind, ps_ind,oz_ind
-    integer(i_kind) :: w_ind
+    integer(i_kind) :: u_ind, v_ind, tv_ind, tsen_ind,q_ind, ps_ind,oz_ind,dbz_ind
+    integer(i_kind) :: w_ind, cw_ind, ph_ind
     integer(i_kind) :: ql_ind, qi_ind, qr_ind, qs_ind, qg_ind, qnr_ind
 
-    integer(i_kind) file_id,file_id1
+    integer(i_kind) file_id,file_id1,file_id2
     real(r_single), dimension(:,:), allocatable ::pswork
     real(r_single), dimension(:,:,:), allocatable ::workvar3d,workinc3d,workinc3d2,uworkvar3d,&
                         vworkvar3d,tvworkvar3d,tsenworkvar3d,&
@@ -652,6 +690,7 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     qs_ind  = getindex(vars3d, 'qs')  ! QS (3D) for FV3
     qg_ind  = getindex(vars3d, 'qg')  ! QG (3D) for FV3
     qnr_ind  = getindex(vars3d, 'qnr')  ! QNR (3D) for FV3
+    dbz_ind  = getindex(vars3d, 'dbz')   ! Reflectivity (3D)
     
     ps_ind  = getindex(vars2d, 'ps')  ! Ps (2D)
 
@@ -699,6 +738,15 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
                call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
                                              fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)) )
                
+               if(dbz_ind > 0) then
+                  call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
+                                         fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)),&
+                                         fileid3=file_id2,fv3fn3=trim(adjustl(fv3filename2)))
+               else
+                  call fv3lamfile%setupfile(fileid1=file_id,fv3fn1=trim(adjustl(fv3filename))  , &
+                                         fileid2=file_id1,fv3fn2=trim(adjustl(fv3filename1)))
+               endif
+
             endif 
 
 
@@ -1006,6 +1054,25 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
 
           endif
 
+          if (dbz_ind > 0) then
+             varstrname = 'ref_f3d'
+             call fv3lamfile%get_idfn(varstrname,file_id,fv3filename)
+             call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+             do k=1,nlevs
+                nn = nn_tile0
+                do j=1,ny_res
+                   do i=1,nx_res
+                      nn=nn+1
+                      workinc3d(i,j,nlevs+1-k)=vargrid(nn,levels(dbz_ind-1)+k,nb,ne)
+                   enddo
+                enddo
+             enddo
+             workvar3d=workvar3d+workinc3d
+             where (workvar3d < 0.0_r_kind) workvar3d = 0.0_r_kind
+             call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+
+          endif
+
           if (ps_ind > 0) then
             allocate(workprsi(nx_res,ny_res,nlevsp1))
             allocate(pswork(nx_res,ny_res))
@@ -1051,7 +1118,8 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
             call nc_check( nf90_close(file_id),&
               myname_,'close '//trim(filename) )
           else
-            do ifile=1,2
+            do ifile=1,3
+              if(dbz_ind <=0 .and. ifile == 3) cycle
               file_id=fv3lamfile%fv3lam_fileid(ifile)
               filename=fv3lamfile%fv3lamfilename(ifile)
               call nc_check( nf90_close(file_id),&
@@ -2478,19 +2546,23 @@ subroutine writegriddata_pnc(vars3d,vars2d,n3d,n2d,levels,ndim,vargrid,no_inflat
     ! Return calculated values
     return
 end subroutine writegriddata_pnc
-subroutine type_bound_setupfile(this,fileid1,fv3fn1,fileid2,fv3fn2)
+subroutine type_bound_setupfile(this,fileid1,fv3fn1,fileid2,fv3fn2,fileid3,fv3fn3)
        implicit none
        class (type_fv3lamfile) :: this  
        integer(i_kind) fileid1
-       integer(i_kind), optional :: fileid2
+       integer(i_kind), optional :: fileid2,fileid3
        character(len=*)::fv3fn1
-       character(len=*),optional ::fv3fn2
+       character(len=*),optional ::fv3fn2,fv3fn3
        if (present (fileid2)) then
          this%l_filecombined=.false. 
          this%fv3lamfilename(1)=trim(fv3fn1)
          this%fv3lamfilename(2)=trim(fv3fn2)
          this%fv3lam_fileid(1)=fileid1
          this%fv3lam_fileid(2)=fileid2
+         if (present (fileid3)) then
+            this%fv3lamfilename(3)=trim(fv3fn3)
+            this%fv3lam_fileid(3)=fileid3
+         endif
        else
          this%l_filecombined=.true. 
          this%fv3lamfilename(1)=fv3fn1
@@ -2509,6 +2581,9 @@ subroutine type_bound_getidfn(this,vnamloc,fileid,fv3fn)
          else if(ifindstrloc(vartracers,vnamloc)> 0)  then  
            fv3fn=trim(this%fv3lamfilename(2))
            fileid=this%fv3lam_fileid(2)
+         else if(ifindstrloc(varphysics,vnamloc)> 0)  then  
+           fv3fn=trim(this%fv3lamfilename(3))
+           fileid=this%fv3lam_fileid(3)
          else
            write(6,*)"the varname ",trim(vnamloc)," is not recognized in the ype_bound_getidfn, stop"
            call stop2(23)

--- a/src/enkf/gridio_fv3reg.f90
+++ b/src/enkf/gridio_fv3reg.f90
@@ -507,7 +507,7 @@ contains
                enddo
                do k = levels(dbz_ind-1)+1, levels(dbz_ind)
                    if (nproc .eq. 0)                                               &
-                      write(6,*) 'READFVregional : qnr ',                           &
+                      write(6,*) 'READFVregional : dbz ',                           &
                           & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
                enddo
 

--- a/src/gsi/gsi_dbzOper.F90
+++ b/src/gsi/gsi_dbzOper.F90
@@ -83,6 +83,10 @@ contains
     use jfunc   , only: jiter
 
     use mpeu_util, only: die
+
+    use directDA_radaruse_mod, only: l_use_dbz_directDA
+    use obsmod, only: dirname, ianldate
+
     implicit none
     class(dbzOper ), intent(inout):: self
     integer(i_kind), intent(in):: lunin
@@ -99,8 +103,30 @@ contains
     character(len=len_isis   ):: isis
     integer(i_kind):: nreal,nchanl,ier,nele
     logical:: diagsave
+    integer(i_kind):: lu_diag
+    character(128):: diag_file
+    character(80):: string
 
-    if(nobs == 0) return
+    if(nobs == 0) then
+
+       if(mype == 0) then
+          write(6,*) 'init_pass = ', init_pass
+          write(6,*) 'l_use_dbz_directDA = ', l_use_dbz_directDA
+       endif
+
+       if( (mype == 0) .and. init_pass .and. (.not. l_use_dbz_directDA) ) then
+          write(string,600) jiter
+600       format('radardbz_',i2.2)
+          diag_file=trim(dirname) // trim(string)
+          write(6,*) 'write ianldate to ', diag_file
+          open(newunit=lu_diag,file=trim(diag_file),form='unformatted',status='unknown',position='rewind')
+          write(lu_diag) ianldate
+          close(lu_diag)
+       endif
+
+       return
+
+    endif
 
     read(lunin,iostat=ier) obstype,isis,nreal,nchanl
     if(ier/=0) call die(myname_,'read(obstype,...), iostat =',ier)

--- a/src/gsi/gsi_dbzOper.F90
+++ b/src/gsi/gsi_dbzOper.F90
@@ -109,11 +109,6 @@ contains
 
     if(nobs == 0) then
 
-       if(mype == 0) then
-          write(6,*) 'init_pass = ', init_pass
-          write(6,*) 'l_use_dbz_directDA = ', l_use_dbz_directDA
-       endif
-
        if( (mype == 0) .and. init_pass .and. (.not. l_use_dbz_directDA) ) then
           write(string,600) jiter
 600       format('radardbz_',i2.2)

--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -2031,7 +2031,8 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z,ges_t2m,ges_q2m)
           end do
        end do
 
-       if(allocated(sfc1) .and. allocated(sfc))deallocate (dim_id,sfc,sfc1,dim)
+       if(allocated(sfc1) .and. allocated(sfc)) deallocate (sfc,sfc1)
+       if(allocated(dim)) deallocate (dim)
        if(allocated(sfc_fulldomain)) deallocate (sfc_fulldomain)
     endif  ! mype
 

--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -538,7 +538,7 @@ subroutine read_fv3_files(mype)
 ! Declare local variables
     logical(4) fexist
     character(6) filename
-    character(14) filenames
+    character(19) filenames
     integer(i_kind) in_unit
     integer(i_kind) i,j,iwan,npem1
     integer(i_kind) nhr_half
@@ -573,11 +573,19 @@ subroutine read_fv3_files(mype)
        in_unit=15
        iwan=0
 !WWWWWW setup for one first guess file for now
-      do i=0,9 !place holder for FGAT
+       do i=0,9 !place holder for FGAT
           if ( i == 6 ) then
-            write(filenames,"(A11)") 'fv3_dynvars'
+             if(fv3_io_layout_y > 1) then
+                write(filenames,"(A16)") 'fv3_dynvars.0000'
+             else
+                write(filenames,"(A11)") 'fv3_dynvars'
+             endif
           else
-            write(filenames,"(A12,I2.2)") 'fv3_dynvars_',i
+             if(fv3_io_layout_y > 1) then
+                write(filenames,"(A17,I2.2)") 'fv3_dynvars.0000_',i
+             else
+                write(filenames,"(A12,I2.2)") 'fv3_dynvars_',i
+             endif
           endif
           INQUIRE(FILE=filenames, EXIST=fexist)
           if(.not.fexist) cycle
@@ -1119,7 +1127,7 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin)
         if (allocated(fv3lam_io_dynmetvars2d_nouv)) &
           write(6,*)' fv3lam_io_dynmetvars2d_nouv is ',(trim(fv3lam_io_dynmetvars2d_nouv(i)), i=1,ndynvario2d)
         if (allocated(fv3lam_io_tracermetvars2d_nouv))&
-          write(6,*)'fv3lam_io_dynmetvars2d_nouv is ',(trim(fv3lam_io_dynmetvars2d_nouv(i)),i=1,ntracerio3d)
+          write(6,*)'fv3lam_io_tracermetvars2d_nouv is ',(trim(fv3lam_io_tracermetvars2d_nouv(i)),i=1,ntracerio2d)
       endif      
 
       if (laeroana_fv3cmaq) then
@@ -1783,6 +1791,8 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z,ges_t2m,ges_q2m)
 ! abstract: read in 2d fields from fv3_sfcdata file in mype_2d 
 !                Scatter the field to each PE 
 ! program history log:
+!   2023-02-14  Hu   -  Bug fix for read in subdomain surface restart files
+!
 !   input argument list:
 !     it    - time index for 2d fields
 !
@@ -1902,40 +1912,24 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z,ges_t2m,ges_q2m)
              write(*,*) "wrong dimension number ndim =",ndim
              call stop2(119)
           endif
-          if(allocated(dim_id    )) deallocate(dim_id    )
-          allocate(dim_id(ndim))
           if(fv3_io_layout_y > 1) then
              do nio=0,fv3_io_layout_y-1
-               iret=nf90_inquire_variable(gfile_loc_layout(nio),i,dimids=dim_id)
-               if(allocated(sfc       )) deallocate(sfc       )
-               if(dim(dim_id(1)) == nx .and. dim(dim_id(2))==ny_layout_len(nio)) then
-                  if(ndim >=3) then
-                     allocate(sfc(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
-                     iret=nf90_get_var(gfile_loc_layout(nio),i,sfc)
-                  else if (ndim == 2) then
-                     allocate(sfc(dim(dim_id(1)),dim(dim_id(2)),1))
-                     iret=nf90_get_var(gfile_loc_layout(nio),i,sfc(:,:,1))
-                  endif
-               else
-                  write(*,*) "Mismatch dimension in surfacei reading:",nx,ny_layout_len(nio),dim(dim_id(1)),dim(dim_id(2))
-                  call stop2(119)
-               endif
-               sfc_fulldomain(:,ny_layout_b(nio):ny_layout_e(nio))=sfc(:,:,1)
+                if(allocated(sfc       )) deallocate(sfc       )
+                allocate(sfc(nx,ny_layout_len(nio),1))
+                if(ndim >=3) then
+                   iret=nf90_get_var(gfile_loc_layout(nio),i,sfc)
+                else if (ndim == 2) then
+                   iret=nf90_get_var(gfile_loc_layout(nio),i,sfc(:,:,1))
+                endif
+                sfc_fulldomain(:,ny_layout_b(nio):ny_layout_e(nio))=sfc(:,:,1)
              enddo
           else
-             iret=nf90_inquire_variable(gfile_loc,i,dimids=dim_id)
              if(allocated(sfc       )) deallocate(sfc       )
-             if(dim(dim_id(1)) == nx .and. dim(dim_id(2))==ny) then
-                if(ndim >=3) then  !the block of 10 lines is compied from GSL gsi.
-                   allocate(sfc(dim(dim_id(1)),dim(dim_id(2)),dim(dim_id(3))))
-                   iret=nf90_get_var(gfile_loc,i,sfc)
-                else if (ndim == 2) then
-                   allocate(sfc(dim(dim_id(1)),dim(dim_id(2)),1))
-                   iret=nf90_get_var(gfile_loc,i,sfc(:,:,1))
-                endif
-             else
-                write(*,*) "Mismatch dimension in surfacei reading:",nx,ny,dim(dim_id(1)),dim(dim_id(2))
-                call stop2(119)
+             allocate(sfc(nx,ny,1))
+             if(ndim >=3) then 
+                iret=nf90_get_var(gfile_loc,i,sfc)
+             else if (ndim == 2) then
+                iret=nf90_get_var(gfile_loc,i,sfc(:,:,1))
              endif
              sfc_fulldomain(:,:)=sfc(:,:,1)
           endif
@@ -1997,19 +1991,16 @@ subroutine gsi_fv3ncdf2d_read(fv3filenamegin,it,ges_z,ges_t2m,ges_q2m)
           iret=nf90_inquire_variable(gfile_loc,k,name,len)
           if(trim(name)=='PHIS'   .or. trim(name)=='phis'  ) then
              iret=nf90_inquire_variable(gfile_loc,k,ndims=ndim)
-             if(allocated(dim_id    )) deallocate(dim_id    )
-             allocate(dim_id(ndim))
              if(fv3_io_layout_y > 1) then
                 do nio=0,fv3_io_layout_y-1
-                  iret=nf90_inquire_variable(gfile_loc_layout(nio),k,dimids=dim_id)
                   if(allocated(sfc1       )) deallocate(sfc1       )
-                  allocate(sfc1(dim(dim_id(1)),dim(dim_id(2))) )
+                  allocate(sfc1(nx,ny_layout_len(nio)) )
                   iret=nf90_get_var(gfile_loc_layout(nio),k,sfc1)
                   sfc_fulldomain(:,ny_layout_b(nio):ny_layout_e(nio))=sfc1
                 enddo
              else
-                iret=nf90_inquire_variable(gfile_loc,k,dimids=dim_id)
-                allocate(sfc1(dim(dim_id(1)),dim(dim_id(2))) )
+                if(allocated(sfc1       )) deallocate(sfc1       )
+                allocate(sfc1(nx,ny) )
                 iret=nf90_get_var(gfile_loc,k,sfc1)
                 sfc_fulldomain=sfc1
              endif
@@ -3300,6 +3291,7 @@ subroutine wrfv3_netcdf(fv3filenamegin)
        call GSI_BundleGetPointer (GSI_MetGuess_Bundle(it),'q2m',ges_q2m,istatus); ier=ier+istatus
        call GSI_BundleGetPointer (GSI_MetGuess_Bundle(it),'t2m',ges_t2m,istatus );ier=ier+istatus
     endif
+    if (ier/=0) call die('wrfv3_netcdf','cannot get pointers for fv3 met-fields, ier =',ier)
 
     if (laeroana_fv3cmaq) then
       call GSI_BundleGetPointer ( GSI_ChemGuess_Bundle(it), 'aalj',ges_aalj,istatus );ier=ier+istatus

--- a/src/gsi/setupdbz.f90
+++ b/src/gsi/setupdbz.f90
@@ -426,6 +426,7 @@ subroutine setupdbz(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,radardbz_d
      if (lobsdiagsave) nreal=nreal+4*miter+1
      if (.not.allocated(cdiagbuf)) allocate(cdiagbuf(nobs))
      if (.not.allocated(rdiagbuf)) allocate(rdiagbuf(nreal,nobs))
+     if(netcdf_diag) call init_netcdf_diag_
   end if
   mm1=mype+1
   scale=one
@@ -1447,15 +1448,16 @@ subroutine setupdbz(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,radardbz_d
 
 ! Release memory of local guess arrays
   call final_vars_
-
 ! Write information to diagnostic file
-  if(radardbz_diagsave  .and. ii>0 )then
+  if(radardbz_diagsave .and. netcdf_diag) call nc_diag_write
+  if(radardbz_diagsave .and. binary_diag .and. ii>0  )then
 
-     if( .not. l_use_dbz_directDA )then
+     if( .not. l_use_dbz_directDA .and. .not. if_model_dbz )then
         write(7)'dbz',nchar,nreal,ii,mype,ioff0
         write(7)cdiagbuf(1:ii),rdiagbuf(:,1:ii)
         deallocate(cdiagbuf,rdiagbuf)
      else
+
         write(string,600) jiter
 600     format('radardbz_',i2.2)
         diag_file=trim(dirname) // trim(string)
@@ -1779,6 +1781,7 @@ subroutine setupdbz(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,radardbz_d
      end if
 
      call nc_diag_init(diag_conv_file, append=append_diag)
+     call flush(6)
 
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )

--- a/src/gsi/setupdbz.f90
+++ b/src/gsi/setupdbz.f90
@@ -1781,8 +1781,7 @@ subroutine setupdbz(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,radardbz_d
      end if
 
      call nc_diag_init(diag_conv_file, append=append_diag)
-     call flush(6)
-
+    
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )


### PR DESCRIPTION
Several functions added for dBZ analysis in EnKF:
1, Add dBZ ncdiag output for EnKF analysis
2, Enhanced binary dBZ diag output for EnKF analysis 
3, Fix spurious analysis increments when assimilating reflectivity (from OU MAP) 
4, Added EnKF interface for read in dBZ from FV3LAM ensemble forecast (from OU MAP)

Fixed a bug for read in subdomain surface restart files

